### PR TITLE
Demonstrate `assert_that` broken on beam `2.50.0` conda distro (but not pip)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,37 @@
+name: Test assert_that
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    name: Test (beam${{ matrix.beam-version }}, from ${{ matrix.install-from }})
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        beam-version: ["2.49.0", "2.50.0"]
+        install-from: ["pip", "conda"]
+    steps:
+      - name: 🔁 Setup mamba
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+      - name: 🐝 Install beam ${{ matrix.beam-version }} from ${{ matrix.install-from }}
+        shell: bash -l {0}
+        run: ${{ matrix.install-from }} install "apache-beam==${{ matrix.beam-version }}"
+      - name: 🧪 Install pytest
+        shell: bash -l {0}
+        run: pip install pytest
+      - name: 🐍 List conda env
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+      - name: 🏃 Run tests
+        shell: bash -l {0}
+        run: pytest -vvv test_assert_that.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  PYTEST_ADDOPTS: "--color=yes"
+
 jobs:
   test:
     name: Test (beam${{ matrix.beam-version }}, from ${{ matrix.install-from }})
@@ -14,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         beam-version: ["2.49.0", "2.50.0"]
-        install-from: ["pip", "conda"]
+        install-from: ["pip", "mamba"]
     steps:
       - name: 🛍️ Checkout
         uses: actions/checkout@v4
@@ -25,7 +28,9 @@ jobs:
           miniforge-version: latest
       - name: 🐝 Install beam ${{ matrix.beam-version }} from ${{ matrix.install-from }}
         shell: bash -l {0}
-        run: ${{ matrix.install-from }} install "apache-beam==${{ matrix.beam-version }}"
+        run: >
+          ${{ matrix.install-from }} install "apache-beam==${{ matrix.beam-version }}"
+          `if [ "${{ matrix.install-from }}" = "mamba" ]; then echo "-y"; fi`
       - name: 🧪 Install pytest
         shell: bash -l {0}
         run: pip install pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,8 @@ jobs:
         beam-version: ["2.49.0", "2.50.0"]
         install-from: ["pip", "conda"]
     steps:
+      - name: 🛍️ Checkout
+        uses: actions/checkout@v4
       - name: 🔁 Setup mamba
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# beam2.50.0-assert-that-bug
+# beam2.50.0-conda-assert-that-bug

--- a/test_assert_that.py
+++ b/test_assert_that.py
@@ -1,0 +1,22 @@
+import apache_beam as beam
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+
+
+def expected_nums():
+    def _expected_nums(actual):
+        assert actual[0] == 0
+        assert actual[1] == 1
+
+    return _expected_nums
+
+
+def test_pipeline_without_assert_that():
+    with TestPipeline() as p:
+        _ = p | beam.Create([0, 1])
+
+
+def test_assert_that():
+    with TestPipeline() as p:
+        nums = p | beam.Create([0, 1])
+        assert_that(nums, expected_nums())


### PR DESCRIPTION
As shown in the test results for https://github.com/cisaacstern/beam2.50.0-assert-that-bug/pull/1/commits/b64b8ce0b4d96e7652e9f1ce510ba94dad910e49, `assert_that` is broken in beam starting with `2.50.0`, _**on conda/mamba only**_:
<img width="600" alt="Screen Shot 2023-09-06 at 4 37 34 PM" src="https://github.com/cisaacstern/beam2.50.0-assert-that-bug/assets/62192187/71439bc6-6469-4fa7-8cbd-572a0b8f3a14">
